### PR TITLE
Remove duplicated HIGH-SIGNAL block in code-review, add a dup test

### DIFF
--- a/commands/code-review.md
+++ b/commands/code-review.md
@@ -57,11 +57,6 @@ Each reviewer must receive the PR title, description, and the relevant project r
 - Clear, unambiguous convention violations (must quote the exact rule)
 - Concrete edge cases that are reachable in production with a specific trigger
 
-**Critical: only HIGH-SIGNAL issues should be flagged.** Do flag:
-- Code that will fail to compile or parse (syntax, type errors, missing imports)
-- Code that will definitely produce wrong results regardless of inputs
-- Clear, unambiguous convention violations (must quote the exact rule)
-
 Do NOT flag:
 - Style or quality concerns that aren't in the project rules
 - Potential issues that depend on specific runtime state or inputs

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -59,11 +59,6 @@ Each reviewer must receive the PR title, description, and the relevant project r
 - Clear, unambiguous convention violations (must quote the exact rule)
 - Concrete edge cases that are reachable in production with a specific trigger
 
-**Critical: only HIGH-SIGNAL issues should be flagged.** Do flag:
-- Code that will fail to compile or parse (syntax, type errors, missing imports)
-- Code that will definitely produce wrong results regardless of inputs
-- Clear, unambiguous convention violations (must quote the exact rule)
-
 Do NOT flag:
 - Style or quality concerns that aren't in the project rules
 - Potential issues that depend on specific runtime state or inputs

--- a/tests/skill-lint.test.mjs
+++ b/tests/skill-lint.test.mjs
@@ -56,4 +56,19 @@ for (const name of names) {
     const cmd = parse(readFileSync(cmdPath, "utf8"));
     assert.match((cmd.fm.description ?? "").trim(), SENTENCE_END, "command description not truncated");
   });
+
+  test(`${name}: no duplicated block`, () => {
+    const check = (label, text) => {
+      const seen = new Set();
+      for (const raw of text.split(/\r?\n/)) {
+        const line = raw.replace(/\s+$/, "");
+        if (line.trim().length >= 50) {
+          assert.ok(!seen.has(line), `${label} repeats a line verbatim: "${line.slice(0, 60)}..."`);
+          seen.add(line);
+        }
+      }
+    };
+    check("SKILL.md", readFileSync(join(skillsDir, name, "SKILL.md"), "utf8"));
+    check("command", readFileSync(cmdPath, "utf8"));
+  });
 }


### PR DESCRIPTION
## Summary

- The `**Critical: only HIGH-SIGNAL issues should be flagged.**` block appeared
  twice, back to back, in `code-review`'s `SKILL.md` and command. The second copy
  was a strict subset of the first (it dropped the "Concrete edge cases" bullet),
  so it was pure redundancy. The duplicate is removed; the complete first copy stays.
- The skill-lint suite gains a per-skill **"no duplicated block"** check (no
  non-empty line ≥ 50 chars repeats within a `SKILL.md` or its command), catching
  this class of copy-paste error going forward.
- `SKILL.md` and command stay in sync.

## Validation

- **Deterministic:** `npm test` → **55/55 pass** (44 prior + 11 new duplicate-block
  checks; `code-review: no duplicated block` ✔).
- **Behavioral:** ran `code-review` locally via `opencode run` against a fixture
  with a planted off-by-one bug (`return items[idx + 1]`). Both models caught it at
  confidence 100 — full responses below.

### Model outputs

<details>
<summary><b>DeepSeek V4 Flash Free</b> — full finding</summary>

````
**Summary of change:** Modifies `util.py:get_item()` to add a comment and change the return from `items[idx]` to `items[idx + 1]`.

---

## Issues Found

### Critical

**1. Off-by-one bug in `get_item` — `util.py:3`**
- **Severity:** Critical
- **Confidence:** 100
- **Problem:** `return items[idx + 1]` returns the element *after* the requested index. The comment added in the same change confirms the intent was "return the item at idx" — the code contradicts it.
- **Category:** Logic error (off-by-one)
- **Reproduction scenario:** `get_item([10, 20, 30], 0)` returns `20` instead of `10`; `get_item([10, 20, 30], 2)` raises `IndexError`.
- **Fix:** Change `items[idx + 1]` to `items[idx]` on line 3.

One issue found and fixed. The change introduced a clear off-by-one bug on `util.py:3` — `items[idx + 1]` should be `items[idx]`. The comment added in the same diff confirms the intent was to return the item at `idx`, not `idx + 1`. Fix has been applied.
````

</details>

<details>
<summary><b>GPT-5.5</b> — full finding</summary>

````
**Important**
`util.py:3`
Severity: Important
Confidence: 100
Problem: `get_item(items, idx)` now returns `items[idx + 1]`, so it returns the next element instead of the requested index and fails at the last valid index.

Reproduction:
```python
get_item(["a", "b"], 0)  # returns "b", expected "a"
get_item(["a", "b"], 1)  # raises IndexError, expected "b"
```

Fix: restore `return items[idx]`.

Bug category: Logic error / off-by-one boundary error.
````

</details>

> Both runs used `opencode run --command`-equivalent prompts on the same fixture; GPT-5.5 additionally dispatched the seven reviewer passes as parallel sub-agents.
