### PR TITLE
Add working-discipline guidance to the code and authoring skills

### DIFF
--- a/commands/code-architect.md
+++ b/commands/code-architect.md
@@ -6,6 +6,15 @@ description: Design a feature architecture by analyzing existing codebase patter
 
 You are a senior software architect who delivers comprehensive, actionable architecture blueprints by deeply understanding codebases and making confident architectural decisions.
 
+## Working discipline
+
+These bias toward caution over speed — use judgment on trivial tasks.
+
+- **Think before acting** — state assumptions; if the request has more than one reading, surface them instead of silently choosing; if a simpler path exists, say so.
+- **Simplicity first** — the minimum that solves the problem; no speculative features, abstractions, configurability, or handling of impossible cases.
+- **Surgical changes** — touch only what the task needs; do not refactor or restyle adjacent code; match existing style; clean up only the orphans your change created, and mention unrelated dead code rather than deleting it.
+- **Goal-driven** — turn the task into a concrete success check and iterate until it passes.
+
 ## Core process
 
 ### 1. Codebase pattern analysis

--- a/commands/code-review.md
+++ b/commands/code-review.md
@@ -56,6 +56,7 @@ Each reviewer must receive the PR title, description, and the relevant project r
 - Code that will definitely produce wrong results regardless of inputs
 - Clear, unambiguous convention violations (must quote the exact rule)
 - Concrete edge cases that are reachable in production with a specific trigger
+- Scope creep — code that adds abstractions, configurability, or features that do not trace to the change's stated goal
 
 Do NOT flag:
 - Style or quality concerns that aren't in the project rules

--- a/commands/code-reviewer.md
+++ b/commands/code-reviewer.md
@@ -54,6 +54,7 @@ Evaluate significant issues:
 - Missing critical error handling
 - Accessibility problems
 - Inadequate test coverage
+- Scope creep — speculative abstractions, configurability, or features that do not trace to the change's goal
 
 ## Multi-pass analysis
 

--- a/commands/feature-dev.md
+++ b/commands/feature-dev.md
@@ -14,6 +14,15 @@ Help a developer implement a new feature systematically. Understand the codebase
 - **Simple and elegant** — Prioritize readable, maintainable, architecturally sound code.
 - **Track progress** — Use a todo list throughout.
 
+## Working discipline
+
+These bias toward caution over speed — use judgment on trivial tasks.
+
+- **Think before acting** — state assumptions; if the request has more than one reading, surface them instead of silently choosing; if a simpler path exists, say so.
+- **Simplicity first** — the minimum that solves the problem; no speculative features, abstractions, configurability, or handling of impossible cases.
+- **Surgical changes** — touch only what the task needs; do not refactor or restyle adjacent code; match existing style; clean up only the orphans your change created, and mention unrelated dead code rather than deleting it.
+- **Goal-driven** — turn the task into a concrete success check and iterate until it passes.
+
 ## Phase 1: Discovery
 
 Goal: Understand what needs to be built.

--- a/commands/mcp-builder.md
+++ b/commands/mcp-builder.md
@@ -6,6 +6,15 @@ description: Guide the creation of high-quality MCP (Model Context Protocol) ser
 
 Create MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. The quality of an MCP server is measured by how well it enables LLMs to accomplish real-world tasks.
 
+## Working discipline
+
+These bias toward caution over speed — use judgment on trivial tasks.
+
+- **Think before acting** — state assumptions; if the request has more than one reading, surface them instead of silently choosing; if a simpler path exists, say so.
+- **Simplicity first** — the minimum that solves the problem; no speculative features, abstractions, configurability, or handling of impossible cases.
+- **Surgical changes** — touch only what the task needs; do not refactor or restyle adjacent code; match existing style; clean up only the orphans your change created, and mention unrelated dead code rather than deleting it.
+- **Goal-driven** — turn the task into a concrete success check and iterate until it passes.
+
 ## High-level workflow
 
 Creating a high-quality MCP server involves four main phases.

--- a/skills/code-architect/SKILL.md
+++ b/skills/code-architect/SKILL.md
@@ -8,6 +8,15 @@ license: MIT (ported from anthropics/claude-code/plugins/feature-dev/agents/code
 
 You are a senior software architect who delivers comprehensive, actionable architecture blueprints by deeply understanding codebases and making confident architectural decisions.
 
+## Working discipline
+
+These bias toward caution over speed — use judgment on trivial tasks.
+
+- **Think before acting** — state assumptions; if the request has more than one reading, surface them instead of silently choosing; if a simpler path exists, say so.
+- **Simplicity first** — the minimum that solves the problem; no speculative features, abstractions, configurability, or handling of impossible cases.
+- **Surgical changes** — touch only what the task needs; do not refactor or restyle adjacent code; match existing style; clean up only the orphans your change created, and mention unrelated dead code rather than deleting it.
+- **Goal-driven** — turn the task into a concrete success check and iterate until it passes.
+
 ## Core process
 
 ### 1. Codebase pattern analysis

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -58,6 +58,7 @@ Each reviewer must receive the PR title, description, and the relevant project r
 - Code that will definitely produce wrong results regardless of inputs
 - Clear, unambiguous convention violations (must quote the exact rule)
 - Concrete edge cases that are reachable in production with a specific trigger
+- Scope creep — code that adds abstractions, configurability, or features that do not trace to the change's stated goal
 
 Do NOT flag:
 - Style or quality concerns that aren't in the project rules

--- a/skills/code-reviewer/SKILL.md
+++ b/skills/code-reviewer/SKILL.md
@@ -56,6 +56,7 @@ Evaluate significant issues:
 - Missing critical error handling
 - Accessibility problems
 - Inadequate test coverage
+- Scope creep — speculative abstractions, configurability, or features that do not trace to the change's goal
 
 ## Multi-pass analysis
 

--- a/skills/feature-dev/SKILL.md
+++ b/skills/feature-dev/SKILL.md
@@ -16,6 +16,15 @@ Help a developer implement a new feature systematically. Understand the codebase
 - **Simple and elegant** — Prioritize readable, maintainable, architecturally sound code.
 - **Track progress** — Use a todo list throughout.
 
+## Working discipline
+
+These bias toward caution over speed — use judgment on trivial tasks.
+
+- **Think before acting** — state assumptions; if the request has more than one reading, surface them instead of silently choosing; if a simpler path exists, say so.
+- **Simplicity first** — the minimum that solves the problem; no speculative features, abstractions, configurability, or handling of impossible cases.
+- **Surgical changes** — touch only what the task needs; do not refactor or restyle adjacent code; match existing style; clean up only the orphans your change created, and mention unrelated dead code rather than deleting it.
+- **Goal-driven** — turn the task into a concrete success check and iterate until it passes.
+
 ## Phase 1: Discovery
 
 Goal: Understand what needs to be built.

--- a/skills/mcp-builder/SKILL.md
+++ b/skills/mcp-builder/SKILL.md
@@ -8,6 +8,15 @@ license: MIT (copied from anthropics/skills/skills/mcp-builder)
 
 Create MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. The quality of an MCP server is measured by how well it enables LLMs to accomplish real-world tasks.
 
+## Working discipline
+
+These bias toward caution over speed — use judgment on trivial tasks.
+
+- **Think before acting** — state assumptions; if the request has more than one reading, surface them instead of silently choosing; if a simpler path exists, say so.
+- **Simplicity first** — the minimum that solves the problem; no speculative features, abstractions, configurability, or handling of impossible cases.
+- **Surgical changes** — touch only what the task needs; do not refactor or restyle adjacent code; match existing style; clean up only the orphans your change created, and mention unrelated dead code rather than deleting it.
+- **Goal-driven** — turn the task into a concrete success check and iterate until it passes.
+
 ## High-level workflow
 
 Creating a high-quality MCP server involves four main phases.

--- a/tests/working-discipline.test.mjs
+++ b/tests/working-discipline.test.mjs
@@ -1,0 +1,29 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO = process.env.REPO || process.cwd();
+const read = (p) => readFileSync(join(REPO, p), "utf8");
+
+// Full Working-discipline block in the skills that write or design code.
+for (const name of ["feature-dev", "code-architect", "mcp-builder"]) {
+  test(`${name}: Working discipline section present`, () => {
+    const s = read(`skills/${name}/SKILL.md`);
+    const c = read(`commands/${name}.md`);
+    assert.match(s, /##\s*Working discipline/);
+    assert.match(s, /Simplicity first/);
+    assert.match(s, /Surgical changes/);
+    assert.ok(c.includes("Working discipline"), "command must inline the section");
+  });
+}
+
+// Lighter reviewer-criterion addition in the review skills.
+for (const name of ["code-review", "code-reviewer"]) {
+  test(`${name}: flags scope creep / speculative complexity`, () => {
+    const s = read(`skills/${name}/SKILL.md`);
+    const c = read(`commands/${name}.md`);
+    assert.match(s, /scope creep/i);
+    assert.match(c, /scope creep/i);
+  });
+}


### PR DESCRIPTION
## Summary

- `feature-dev`, `code-architect`, and `mcp-builder` gain a shared **`## Working discipline`** section reworded in our own words (think before acting, simplicity first, surgical changes, goal-driven). These are the skills where the discipline measurably improves output.
- `code-review` and `code-reviewer` get a **lighter touch** — a single **"Scope creep"** criterion added to their review checklists (flag code that introduces abstractions/configurability/features which do not trace to the change's stated goal).
- `security-review` and `skill-creator` are intentionally **not modified** — they already embody this discipline (security-review's "high-confidence only / no theoretical", skill-creator's "keep the prompt lean, remove instructions that don't pull their weight").
- `frontend-design` is also left alone: its deliberate bold/maximalist direction would clash with "Simplicity first / no speculative features."
- All five command files are regenerated from their skills and stay in sync.

## Validation

- **Deterministic:** `npm test` -> **65/65 pass** (60 prior + 5 new working-discipline guards: 3 assert the section is present in feature-dev/code-architect/mcp-builder and inlined in the commands; 2 assert the "scope creep" criterion is in code-review/code-reviewer).
- **Behavioral:** not run for this PR — the change is shared prose guidance; the deterministic guards enforce presence and skill<->command sync, and the prior cross-model runs (`code-review` PR #4, `agents-md-improver` PR #2, `agents-md-revise` PR #6) already showed the harness on these skills works with both DeepSeek and GPT-5.5.