### PR TITLE
Limit install footprint and expand AI-context .gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,37 @@
-# Personal / private context files
+# Personal / private context files (AI agent context)
+# Claude Code
 CLAUDE.md
+CLAUDE.local.md
 .claude/
 .claude.local.md
+
+# OpenCode / Codex / agentes genéricos
+AGENTS.md
+AGENTS.local.md
 .agents.local.md
 AGENTS.md.local
+.codex/
+codex.md
+CODEX.md
+
+# Cursor
+.cursorrules
+.cursor/
+.cursorignore
+
+# Windsurf
+.windsurfrules
+.windsurf/
+
+# GitHub Copilot
+.github/copilot-instructions.md
+
+# Gemini / otros
+GEMINI.md
+.gemini/
+.aider*
+.continue/
+.aiderignore
 
 # Personal memory / notes
 memory/

--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "description": "Curated bundle of Claude Code skills ported to OpenCode: code-review, feature-dev, security-review, frontend-design, mcp-builder, skill-creator, and the feature-dev sub-agents.",
   "type": "module",
   "main": ".opencode/plugins/opencode-power-pack.js",
+  "files": [
+    "skills",
+    "commands",
+    ".opencode",
+    "assets"
+  ],
   "scripts": {
     "test": "node --test"
   },


### PR DESCRIPTION
## Summary
- Adds a `files` whitelist to `package.json` so `npm install` from the git URL only ships what users need at runtime — `skills/`, `commands/`, `.opencode/`, `assets/`. Internal `tests/`, `docs/`, and CI config remain tracked in git but no longer travel with the install.
- Expands `.gitignore` with patterns for context/rules files of other AI agents (Cursor, Windsurf, GitHub Copilot, Codex, Gemini, Aider, Continue) plus `CLAUDE.local.md` and `AGENTS.local.md`, so contributors using any of those tools don't accidentally commit their private context.