### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ If you already use other plugins (e.g. `superpowers`), keep all of them in the a
 To pin a specific tag (recommended once releases exist):
 
 ```jsonc
-"opencode-power-pack@git+https://github.com/waybarrios/opencode-power-pack.git#v0.1.0"
+"opencode-power-pack@git+https://github.com/waybarrios/opencode-power-pack.git#v0.2.0"
 ```
 
 You still need a local copy of the repo for **step 2** (the slash command files live there). Clone it next to wherever you keep code:
@@ -267,7 +267,7 @@ pkill -f opencode
 opencode
 ```
 
-If you pinned a version in `opencode.json` (e.g. `#v0.1.0`), bump the tag in the JSON before restarting, otherwise OpenCode keeps using the pinned commit.
+If you pinned a version in `opencode.json` (e.g. `#v0.2.0`), bump the tag in the JSON before restarting, otherwise OpenCode keeps using the pinned commit.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-power-pack",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Curated bundle of Claude Code skills ported to OpenCode: code-review, feature-dev, security-review, frontend-design, mcp-builder, skill-creator, and the feature-dev sub-agents.",
   "type": "module",
   "main": ".opencode/plugins/opencode-power-pack.js",


### PR DESCRIPTION
## Summary
- Bumps `package.json` version from `0.1.0` to `0.2.0`.
- Updates the two pinned-install examples in `README.md` (lines 155 and 270) from `#v0.1.0` to `#v0.2.0`.
- Leaves the Troubleshooting note about a "pre-`v0.1.0` build" untouched — it refers to a historical cache state, not the current version.

After merge: tag the merge commit as `v0.2.0`, push the tag, and publish a GitHub Release with notes covering everything that landed since v0.1.0 (working-discipline guidance, first-match-wins for `agents-md-revise`, `files` whitelist for install footprint, expanded `.gitignore`).