### PR TITLE
Correct skill provenance and licensing

### DIFF
--- a/.opencode/plugins/opencode-power-pack.js
+++ b/.opencode/plugins/opencode-power-pack.js
@@ -20,10 +20,9 @@
  * `config` hook) is adapted directly from Jesse Vincent's superpowers
  * plugin: https://github.com/obra/superpowers
  *
- * The skills under skills/ are ports/translations of artifacts originally
- * written by Anthropic for Claude Code. See README.md → Acknowledgments
- * and each SKILL.md's `license` frontmatter for the specific upstream of
- * each skill.
+ * The skills under skills/ are modified upstream works. See UPSTREAMS.json
+ * for immutable source commits and blobs, and THIRD_PARTY_NOTICES.md for
+ * their licenses and attribution.
  * ─────────────────────────────────────────────────────────────────────────
  */
 

--- a/LICENSES/Anthropic-security-review-MIT.txt
+++ b/LICENSES/Anthropic-security-review-MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Anthropic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!) The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2026 Anthropic, PBC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/Superpowers-MIT.txt
+++ b/LICENSES/Superpowers-MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jesse Vincent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/waybarrios/opencode-power-pack/blob/main/LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square"></a>
+  <a href="https://github.com/waybarrios/opencode-power-pack/blob/main/THIRD_PARTY_NOTICES.md"><img alt="License: MIT and Apache-2.0" src="https://img.shields.io/badge/license-MIT%20%2B%20Apache--2.0-brightgreen?style=flat-square"></a>
   <a href="https://github.com/waybarrios/opencode-power-pack/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/waybarrios/opencode-power-pack?style=flat-square&color=FFD60A"></a>
   <a href="https://github.com/waybarrios/opencode-power-pack/commits/main"><img alt="Last commit" src="https://img.shields.io/github/last-commit/waybarrios/opencode-power-pack?style=flat-square"></a>
   <a href="https://github.com/waybarrios/opencode-power-pack/issues"><img alt="Issues" src="https://img.shields.io/github/issues/waybarrios/opencode-power-pack?style=flat-square"></a>
@@ -27,7 +27,7 @@
 </p>
 
 <p align="center">
-  <i>Built on top of <a href="https://github.com/anthropics/claude-code">anthropics/claude-code</a>,
+  <i>Built on top of <a href="https://github.com/anthropics/claude-plugins-official">anthropics/claude-plugins-official</a>,
   <a href="https://github.com/anthropics/skills">anthropics/skills</a>,
   <a href="https://github.com/anthropics/claude-code-security-review">anthropics/claude-code-security-review</a>,
   and <a href="https://github.com/obra/superpowers">obra/superpowers</a>. See <a href="#acknowledgments">Acknowledgments</a>.</i>
@@ -57,34 +57,34 @@ It pairs nicely with **[obra/superpowers](https://github.com/obra/superpowers)**
 
 <tr><td rowspan="2"><b>Review</b></td>
 <td><code>code-review</code></td>
-<td>translated · plugins/code-review</td>
+<td>adapted · claude-plugins-official/code-review</td>
 <td>Multi-agent PR review with confidence-filtered cross-checks and reproduction scenarios</td></tr>
 <tr><td><code>security-review</code></td>
-<td>translated · claude-code-security-review</td>
+<td>adapted · claude-code-security-review</td>
 <td>OWASP-bucketed, three-stage filtering, requires concrete attack PoC per finding</td></tr>
 
 <tr><td rowspan="4"><b>Feature dev</b></td>
 <td><code>feature-dev</code></td>
-<td>translated · plugins/feature-dev</td>
+<td>ported · claude-plugins-official/feature-dev</td>
 <td>Seven-phase guided workflow: discovery → exploration → questions → architecture → impl → review → summary</td></tr>
 <tr><td><code>code-explorer</code></td>
-<td>translated · feature-dev/agents</td>
+<td>ported · claude-plugins-official/feature-dev</td>
 <td>Deep codebase analysis sub-task — traces a feature end-to-end</td></tr>
 <tr><td><code>code-architect</code></td>
-<td>translated · feature-dev/agents</td>
+<td>ported · claude-plugins-official/feature-dev</td>
 <td>Decisive architecture blueprint sub-task with file-level implementation map</td></tr>
 <tr><td><code>code-reviewer</code></td>
-<td>translated · feature-dev/agents</td>
+<td>ported · claude-plugins-official/feature-dev</td>
 <td>Two-pass adversarial review sub-task with explicit edge-case checklist</td></tr>
 
 <tr><td><b>Design</b></td>
 <td><code>frontend-design</code></td>
-<td>copied · plugins/frontend-design</td>
+<td>adapted · claude-plugins-official/frontend-design</td>
 <td>Distinctive, production-grade UI generation that avoids generic AI aesthetics</td></tr>
 
 <tr><td rowspan="2"><b>Authoring</b></td>
 <td><code>mcp-builder</code></td>
-<td>copied · skills/mcp-builder</td>
+<td>adapted · anthropics/skills/mcp-builder</td>
 <td>Build high-quality MCP servers (Python or TypeScript)</td></tr>
 <tr><td><code>skill-creator</code></td>
 <td>adapted · skills/skill-creator</td>
@@ -149,10 +149,10 @@ If you already use other plugins (e.g. `superpowers`), keep all of them in the a
 }
 ```
 
-To pin a specific tag (recommended once releases exist):
+To pin a specific published tag:
 
 ```jsonc
-"opencode-power-pack@git+https://github.com/waybarrios/opencode-power-pack.git#v0.2.0"
+"opencode-power-pack@git+https://github.com/waybarrios/opencode-power-pack.git#<tag>"
 ```
 
 You still need a local copy of the repo for **step 2** (the slash command files live there). Clone it next to wherever you keep code:
@@ -267,7 +267,7 @@ pkill -f opencode
 opencode
 ```
 
-If you pinned a version in `opencode.json` (e.g. `#v0.2.0`), bump the tag in the JSON before restarting, otherwise OpenCode keeps using the pinned commit.
+If you pinned a version in `opencode.json`, bump the tag in the JSON before restarting, otherwise OpenCode keeps using the pinned commit.
 
 ---
 
@@ -386,7 +386,7 @@ The plugin entry-point only registers the skills path. Slash commands are **phys
 |---|---|
 | Porting Claude Code skills where the methodology is portable | Claude Code slash commands ported as Claude-Code-style commands |
 | Translating commands and agents into SKILL.md format | Claude Code hooks |
-| Direct copies of `anthropics/skills` skills with attribution | Claude Code output styles |
+| Licensed adaptations of upstream skills with immutable provenance | Claude Code output styles |
 | OpenCode-native slash commands generated from skills | Anything that breaks if you also use Claude Code |
 
 ---
@@ -411,19 +411,19 @@ Skill format must follow the OpenCode spec:
 
 ## Acknowledgments
 
-**This package is not original work.** Almost everything in `skills/` is either a direct copy or a translation of skills, commands, or agent definitions written by **Anthropic** for Claude Code, plus one direct adaptation of the OpenCode plugin pattern from **Jesse Vincent (obra)**. The credit belongs to them; this repo's contribution is the *porting and packaging* for OpenCode.
+**The bundled skills are modified upstream works.** Most content in `skills/` is adapted from skills, commands, or agent definitions written by **Anthropic**, plus an adaptation of the OpenCode plugin pattern from **Jesse Vincent (obra)**. This repository contributes the OpenCode port, packaging, and additional workflow guidance. Exact sources and Git blobs are recorded in [`UPSTREAMS.json`](UPSTREAMS.json).
 
 ### Upstream sources
 
 | Upstream | Project | What we use from it |
 |---|---|---|
-| Anthropic | [`anthropics/claude-code/plugins/code-review`](https://github.com/anthropics/claude-code/tree/main/plugins/code-review) | The four-reviewer parallel-review methodology that became `code-review` |
-| Anthropic | [`anthropics/claude-code/plugins/feature-dev`](https://github.com/anthropics/claude-code/tree/main/plugins/feature-dev) | The seven-phase workflow and the three sub-agents (`code-explorer`, `code-architect`, `code-reviewer`) |
-| Anthropic | [`anthropics/claude-code/plugins/frontend-design`](https://github.com/anthropics/claude-code/tree/main/plugins/frontend-design) | The `frontend-design` skill (direct copy) |
-| Anthropic | [`anthropics/claude-code-security-review`](https://github.com/anthropics/claude-code-security-review) | The `/security-review` slash command, translated and extended |
-| Anthropic | [`anthropics/skills/skills/mcp-builder`](https://github.com/anthropics/skills/tree/main/skills/mcp-builder) | The `mcp-builder` skill (direct copy, references stripped) |
-| Anthropic | [`anthropics/skills/skills/skill-creator`](https://github.com/anthropics/skills/tree/main/skills/skill-creator) | The `skill-creator` skill (adapted, eval-tooling references trimmed) |
-| Anthropic | [`anthropics/claude-plugins-official/.../claude-md-management`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/claude-md-management) | Renamed to `agents-md-improver` and `agents-md-revise`; covers AGENTS.md too |
+| Anthropic | [`claude-plugins-official/code-review`](https://github.com/anthropics/claude-plugins-official/tree/bdca23e8e46f8832d0030c05804ae207786ae37f/plugins/code-review) | The confidence-filtered parallel-review methodology adapted as `code-review` |
+| Anthropic | [`claude-plugins-official/feature-dev`](https://github.com/anthropics/claude-plugins-official/tree/bdca23e8e46f8832d0030c05804ae207786ae37f/plugins/feature-dev) | The seven-phase workflow and three specialist roles |
+| Anthropic | [`claude-plugins-official/frontend-design`](https://github.com/anthropics/claude-plugins-official/tree/bdca23e8e46f8832d0030c05804ae207786ae37f/plugins/frontend-design) | The base `frontend-design` methodology, substantially extended here |
+| Anthropic | [`claude-code-security-review`](https://github.com/anthropics/claude-code-security-review/tree/0c6a49f1fa56a1d472575da86a94dbc1edb78eda) | The MIT security-review command, translated and extended |
+| Anthropic | [`anthropics/skills/mcp-builder`](https://github.com/anthropics/skills/tree/5128e1865d670f5d6c9cef000e6dfc4e951fb5b9/skills/mcp-builder) | The base `mcp-builder` workflow, adapted without its original resources |
+| Anthropic | [`anthropics/skills/skill-creator`](https://github.com/anthropics/skills/tree/5128e1865d670f5d6c9cef000e6dfc4e951fb5b9/skills/skill-creator) | The `skill-creator` workflow, adapted without its original eval tooling |
+| Anthropic | [`claude-plugins-official/claude-md-management`](https://github.com/anthropics/claude-plugins-official/tree/bdca23e8e46f8832d0030c05804ae207786ae37f/plugins/claude-md-management) | The base project-memory workflows, expanded to cover AGENTS.md |
 | Jesse Vincent (obra) | [`obra/superpowers`](https://github.com/obra/superpowers) | The OpenCode plugin pattern (`config.skills.paths.push(...)`) used in `.opencode/plugins/opencode-power-pack.js` |
 
 ### What this repo actually contributes
@@ -433,10 +433,10 @@ Skill format must follow the OpenCode spec:
 - Deepening the review skills (`code-review`, `code-reviewer`, `security-review`) with extra reviewers, multi-pass adversarial analysis, mandatory category coverage, and concrete-PoC requirements — the originals were already strong; the ports try to compensate for the smaller models people sometimes run under OpenCode by being more directive
 - Bundling everything as a one-line OpenCode plugin, plus generating physical slash command files that inline each skill's full content
 
-Each individual SKILL.md frontmatter includes a `license` field naming its specific upstream. The wrapper code (the plugin JS, the README, the LICENSE) is the only original-work portion of this repo.
+Each `SKILL.md` and generated command marks itself as modified and names its license. See [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md) for attribution and `UPSTREAMS.json` for immutable provenance.
 
 If you are one of the upstream authors and you'd like the attribution worded differently — or removed — open an issue and we'll fix it.
 
 ## License
 
-MIT for the wrapper code and original work in this repo. Each ported skill cites its upstream source in its frontmatter; upstream Anthropic projects are also MIT-licensed. See [LICENSE](LICENSE) for full attribution.
+The wrapper code and original project material are MIT-licensed under [LICENSE](LICENSE). Modified skills and command prompts derived from Anthropic's official plugins and skills are Apache-2.0, except `security-review`, whose upstream is MIT. See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md), [UPSTREAMS.json](UPSTREAMS.json), and [LICENSES/](LICENSES/) for exact terms and sources.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,57 @@
+# Third-Party Notices
+
+The repository wrapper, plugin integration, packaging, tests, and original
+documentation are licensed under the root MIT `LICENSE` unless a file states
+otherwise.
+
+The skills and generated command prompts are modified derivatives of the
+sources recorded in `UPSTREAMS.json`. They are not represented as original
+work. Every entry records the immutable upstream commit, source path, Git blob,
+license, and adaptation type reviewed for this distribution.
+
+## Anthropic Official Plugins
+
+The following modified skills derive from Apache-2.0 material in
+`anthropics/claude-plugins-official`:
+
+- `agents-md-improver`
+- `agents-md-revise`
+- `code-architect`
+- `code-explorer`
+- `code-review`
+- `code-reviewer`
+- `feature-dev`
+- `frontend-design`
+
+Copyright 2026 Anthropic, PBC. Licensed under Apache-2.0. The full license is
+available at `LICENSES/Apache-2.0.txt`.
+
+## Anthropic Skills
+
+The modified `mcp-builder` and `skill-creator` skills derive from Apache-2.0
+material in `anthropics/skills`.
+
+Copyright 2026 Anthropic, PBC. Licensed under Apache-2.0. The full license is
+available at `LICENSES/Apache-2.0.txt`.
+
+## Anthropic Security Review
+
+The modified `security-review` skill derives from the MIT-licensed
+`anthropics/claude-code-security-review` repository.
+
+Copyright 2025 Anthropic. The upstream notice is available at
+`LICENSES/Anthropic-security-review-MIT.txt`.
+
+## Superpowers OpenCode Plugin Pattern
+
+The skill-path registration pattern in `.opencode/plugins/opencode-power-pack.js`
+is adapted from the MIT-licensed `obra/superpowers` OpenCode plugin.
+
+Copyright 2025 Jesse Vincent. The upstream notice is available at
+`LICENSES/Superpowers-MIT.txt`.
+
+## Modification Notice
+
+All listed skills were changed for OpenCode compatibility, consolidated into
+the `SKILL.md` format, and may include additional local workflow, validation,
+or safety guidance. Consult Git history for the exact local changes.

--- a/UPSTREAMS.json
+++ b/UPSTREAMS.json
@@ -1,0 +1,163 @@
+{
+  "version": 1,
+  "components": [
+    {
+      "name": "opencode-plugin-pattern",
+      "license": "MIT",
+      "adaptation": "adapted",
+      "reviewedAt": "2026-07-27",
+      "source": {
+        "repository": "https://github.com/obra/superpowers",
+        "commit": "6efe32c9e2dd002d0c394e861e0529675d1ab32e",
+        "committedAt": "2026-04-24T02:02:37Z",
+        "path": ".opencode/plugins/superpowers.js",
+        "blob": "48a2b72ddc5ac05718d23647a11b6b169a9a6363"
+      }
+    }
+  ],
+  "skills": [
+    {
+      "name": "agents-md-improver",
+      "license": "Apache-2.0",
+      "adaptation": "adapted",
+      "reviewedAt": "2026-07-27",
+      "source": {
+        "repository": "https://github.com/anthropics/claude-plugins-official",
+        "commit": "bdca23e8e46f8832d0030c05804ae207786ae37f",
+        "committedAt": "2026-04-24T19:52:02Z",
+        "path": "plugins/claude-md-management/skills/claude-md-improver/SKILL.md",
+        "blob": "744444e4df385e9b9160e23fba02321062dfba9a"
+      }
+    },
+    {
+      "name": "agents-md-revise",
+      "license": "Apache-2.0",
+      "adaptation": "translated",
+      "reviewedAt": "2026-07-27",
+      "source": {
+        "repository": "https://github.com/anthropics/claude-plugins-official",
+        "commit": "bdca23e8e46f8832d0030c05804ae207786ae37f",
+        "committedAt": "2026-04-24T19:52:02Z",
+        "path": "plugins/claude-md-management/commands/revise-claude-md.md",
+        "blob": "b7f201db19ec485271945e350914e6ac5a8957bd"
+      }
+    },
+    {
+      "name": "code-architect",
+      "license": "Apache-2.0",
+      "adaptation": "ported",
+      "reviewedAt": "2026-07-27",
+      "source": {
+        "repository": "https://github.com/anthropics/claude-plugins-official",
+        "commit": "bdca23e8e46f8832d0030c05804ae207786ae37f",
+        "committedAt": "2026-04-24T19:52:02Z",
+        "path": "plugins/feature-dev/agents/code-architect.md",
+        "blob": "fcb78bfd11004048fa287ac52c55eb5c17855549"
+      }
+    },
+    {
+      "name": "code-explorer",
+      "license": "Apache-2.0",
+      "adaptation": "ported",
+      "reviewedAt": "2026-07-27",
+      "source": {
+        "repository": "https://github.com/anthropics/claude-plugins-official",
+        "commit": "bdca23e8e46f8832d0030c05804ae207786ae37f",
+        "committedAt": "2026-04-24T19:52:02Z",
+        "path": "plugins/feature-dev/agents/code-explorer.md",
+        "blob": "e0f667ef65f7204399110214defd46ce062a1a51"
+      }
+    },
+    {
+      "name": "code-review",
+      "license": "Apache-2.0",
+      "adaptation": "adapted",
+      "reviewedAt": "2026-07-27",
+      "source": {
+        "repository": "https://github.com/anthropics/claude-plugins-official",
+        "commit": "bdca23e8e46f8832d0030c05804ae207786ae37f",
+        "committedAt": "2026-04-24T19:52:02Z",
+        "path": "plugins/code-review/commands/code-review.md",
+        "blob": "c46e327f19b6bb59dbf9060e8c9961e701908350"
+      }
+    },
+    {
+      "name": "code-reviewer",
+      "license": "Apache-2.0",
+      "adaptation": "ported",
+      "reviewedAt": "2026-07-27",
+      "source": {
+        "repository": "https://github.com/anthropics/claude-plugins-official",
+        "commit": "bdca23e8e46f8832d0030c05804ae207786ae37f",
+        "committedAt": "2026-04-24T19:52:02Z",
+        "path": "plugins/feature-dev/agents/code-reviewer.md",
+        "blob": "7fb589cbd7140152fae41720e391290ba202e57e"
+      }
+    },
+    {
+      "name": "feature-dev",
+      "license": "Apache-2.0",
+      "adaptation": "ported",
+      "reviewedAt": "2026-07-27",
+      "source": {
+        "repository": "https://github.com/anthropics/claude-plugins-official",
+        "commit": "bdca23e8e46f8832d0030c05804ae207786ae37f",
+        "committedAt": "2026-04-24T19:52:02Z",
+        "path": "plugins/feature-dev/commands/feature-dev.md",
+        "blob": "8bdeda3430e43afddbee79830db0f6ea9dfbf36a"
+      }
+    },
+    {
+      "name": "frontend-design",
+      "license": "Apache-2.0",
+      "adaptation": "adapted",
+      "reviewedAt": "2026-07-27",
+      "source": {
+        "repository": "https://github.com/anthropics/claude-plugins-official",
+        "commit": "bdca23e8e46f8832d0030c05804ae207786ae37f",
+        "committedAt": "2026-04-24T19:52:02Z",
+        "path": "plugins/frontend-design/skills/frontend-design/SKILL.md",
+        "blob": "600b6db41fac7e2081c7528ec6982960892c819d"
+      }
+    },
+    {
+      "name": "mcp-builder",
+      "license": "Apache-2.0",
+      "adaptation": "adapted",
+      "reviewedAt": "2026-07-27",
+      "source": {
+        "repository": "https://github.com/anthropics/skills",
+        "commit": "5128e1865d670f5d6c9cef000e6dfc4e951fb5b9",
+        "committedAt": "2026-04-23T17:07:18Z",
+        "path": "skills/mcp-builder/SKILL.md",
+        "blob": "8a1a77a47d141967b246adb4da4f91037578ff7d"
+      }
+    },
+    {
+      "name": "security-review",
+      "license": "MIT",
+      "adaptation": "adapted",
+      "reviewedAt": "2026-07-27",
+      "source": {
+        "repository": "https://github.com/anthropics/claude-code-security-review",
+        "commit": "0c6a49f1fa56a1d472575da86a94dbc1edb78eda",
+        "committedAt": "2026-02-11T18:01:23Z",
+        "path": ".claude/commands/security-review.md",
+        "blob": "93651ea8b92194a1f739eaf5115ea493746df300"
+      }
+    },
+    {
+      "name": "skill-creator",
+      "license": "Apache-2.0",
+      "adaptation": "adapted",
+      "reviewedAt": "2026-07-27",
+      "source": {
+        "repository": "https://github.com/anthropics/skills",
+        "commit": "5128e1865d670f5d6c9cef000e6dfc4e951fb5b9",
+        "committedAt": "2026-04-23T17:07:18Z",
+        "path": "skills/skill-creator/SKILL.md",
+        "blob": "65b3a402dbd09b8e83f9d637c6b553875189085c"
+      }
+    }
+  ]
+}

--- a/commands/agents-md-improver.md
+++ b/commands/agents-md-improver.md
@@ -1,5 +1,6 @@
 ---
 description: Audit and improve project-rules files (AGENTS.md, CLAUDE.md, .agents/instructions, local overrides) so the agent keeps accurate project context. Use when the user asks to check, audit, review, update, improve, or fix their AGENTS.md or CLAUDE.md, mentions "project rules maintenance" or "agent context optimization", or when the codebase has changed enough that the rules file may be stale. Scans the repository for every rules file, grades each against a quality rubric, outputs a quality report, and applies targeted edits only after user approval.
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 # AGENTS.md / CLAUDE.md Improver

--- a/commands/agents-md-revise.md
+++ b/commands/agents-md-revise.md
@@ -1,5 +1,6 @@
 ---
 description: Capture learnings from the current session into the project-rules file (AGENTS.md, CLAUDE.md, or local override) so future sessions benefit. Use when the user says "revise the rules", "update AGENTS.md / CLAUDE.md with what we just learned", "save this to project memory", "remember this for next time", or at the end of a productive session when valuable context has emerged that is not yet documented. This is the COMPLEMENT to agents-md-improver: improver audits, this one captures.
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 # AGENTS.md / CLAUDE.md Revise

--- a/commands/code-architect.md
+++ b/commands/code-architect.md
@@ -1,5 +1,6 @@
 ---
 description: Design a feature architecture by analyzing existing codebase patterns and conventions, then provide a comprehensive implementation blueprint with specific files to create or modify, component designs, data flows, and a build sequence. Use this skill when the user asks for an architecture design, an implementation plan for a non-trivial feature, or when dispatched as a sub-task during feature-dev architecture phase.
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 # Code Architect

--- a/commands/code-explorer.md
+++ b/commands/code-explorer.md
@@ -1,5 +1,6 @@
 ---
 description: Deeply analyze an existing codebase feature by tracing execution paths, mapping architecture layers, understanding patterns and abstractions, and documenting dependencies. Use this skill when you need to understand how a feature works before modifying or extending it, when dispatched as a sub-task during feature-dev exploration, or when the user asks "how does X work in this codebase".
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 # Code Explorer

--- a/commands/code-review.md
+++ b/commands/code-review.md
@@ -1,5 +1,6 @@
 ---
 description: Review a pull request or a set of code changes for bugs, logic errors, and project-convention violations using a confidence-filtered, multi-agent process. Use this skill when the user asks to review a PR, audit pending changes, or inspect a diff for problems before merging.
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 # Code Review

--- a/commands/code-reviewer.md
+++ b/commands/code-reviewer.md
@@ -1,5 +1,6 @@
 ---
 description: Review code for bugs, logic errors, security vulnerabilities, code quality issues, and adherence to project conventions, using confidence-based filtering to report only high-priority issues that truly matter. Use this skill when reviewing a small set of changes locally (such as unstaged diff), when dispatched as a sub-task during feature-dev quality review, or when the user wants a critique of a specific file or function.
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 # Code Reviewer

--- a/commands/feature-dev.md
+++ b/commands/feature-dev.md
@@ -1,5 +1,6 @@
 ---
 description: Guide a feature implementation through a structured seven-phase workflow with deep codebase understanding, clarifying questions, parallel architecture design, and quality review. Use this skill when the user asks to build a new feature, add functionality, or wants a methodical approach to implementation rather than diving straight to code.
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 # Feature Development

--- a/commands/frontend-design.md
+++ b/commands/frontend-design.md
@@ -1,5 +1,6 @@
 ---
 description: Create distinctive, production-grade frontend interfaces with high design quality and accessible markup. Use this skill when the user asks to build or beautify web components, pages, applications, landing pages, dashboards, artifacts, or React/HTML/CSS UI. Generates creative, polished code that avoids generic AI aesthetics, then self-checks it against an objective accessibility and quality rubric.
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices, then audit it against the self-critique rubric before returning.

--- a/commands/mcp-builder.md
+++ b/commands/mcp-builder.md
@@ -1,5 +1,6 @@
 ---
 description: Guide the creation of high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when the user wants to build an MCP server to integrate an external API or service, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 ## Overview
@@ -145,7 +146,7 @@ Create an XML file with this structure:
 
 ## Notes
 
-This is a port of the upstream `mcp-builder` skill from `anthropics/skills`. The original ships bundled reference files (`reference/mcp_best_practices.md`, `reference/node_mcp_server.md`, `reference/python_mcp_server.md`, `reference/evaluation.md`) which are not included in this port. When you need deeper detail, fetch them directly from <https://github.com/anthropics/skills/tree/main/skills/mcp-builder/reference>.
+This is a modified port of the upstream `mcp-builder` skill from `anthropics/skills`. The original ships bundled reference files (`reference/mcp_best_practices.md`, `reference/node_mcp_server.md`, `reference/python_mcp_server.md`, `reference/evaluation.md`) which are not included in this port. The reviewed upstream snapshot is pinned in `UPSTREAMS.json`.
 
 ---
 

--- a/commands/security-review.md
+++ b/commands/security-review.md
@@ -1,5 +1,6 @@
 ---
 description: Perform a focused security review of pending git changes to identify high-confidence security vulnerabilities with real exploitation potential. Use this skill when the user asks for a security review, security audit, vulnerability scan, or wants to check pending changes on a branch for security issues before merging. This is NOT a general code review.
+license: MIT (modified; see UPSTREAMS.json)
 ---
 
 # Security Review

--- a/commands/skill-creator.md
+++ b/commands/skill-creator.md
@@ -1,5 +1,6 @@
 ---
 description: Create new skills (SKILL.md files), modify and improve existing skills, and design skill descriptions for accurate triggering. Use when the user wants to create a new skill from scratch, edit an existing skill, optimize a skill's description, or convert a workflow they just demonstrated into a reusable skill.
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 # Skill Creator
@@ -151,7 +152,7 @@ The `description` field is the primary mechanism that determines whether the mod
 
 ## Notes
 
-This is an adapted port of `anthropics/skills/skills/skill-creator`. The upstream version ships bundled scripts and an HTML eval viewer (`scripts/aggregate_benchmark.py`, `eval-viewer/generate_review.py`, etc.) that are not included here. For automated benchmarking infrastructure, see <https://github.com/anthropics/skills/tree/main/skills/skill-creator>.
+This is a modified port of `anthropics/skills/skills/skill-creator`. The upstream version ships bundled scripts and an HTML eval viewer (`scripts/aggregate_benchmark.py`, `eval-viewer/generate_review.py`, etc.) that are not included here. The reviewed upstream snapshot is pinned in `UPSTREAMS.json`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -8,12 +8,15 @@
     "skills",
     "commands",
     ".opencode",
-    "assets"
+    "assets",
+    "UPSTREAMS.json",
+    "THIRD_PARTY_NOTICES.md",
+    "LICENSES"
   ],
   "scripts": {
     "test": "node --test"
   },
-  "license": "MIT",
+  "license": "MIT AND Apache-2.0",
   "author": "Wayner Barrios",
   "repository": {
     "type": "git",

--- a/skills/agents-md-improver/SKILL.md
+++ b/skills/agents-md-improver/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agents-md-improver
 description: Audit and improve project-rules files (AGENTS.md, CLAUDE.md, .agents/instructions, local overrides) so the agent keeps accurate project context. Use when the user asks to check, audit, review, update, improve, or fix their AGENTS.md or CLAUDE.md, mentions "project rules maintenance" or "agent context optimization", or when the codebase has changed enough that the rules file may be stale. Scans the repository for every rules file, grades each against a quality rubric, outputs a quality report, and applies targeted edits only after user approval.
-license: MIT (adapted from anthropics/claude-plugins-official/plugins/claude-md-management/skills/claude-md-improver)
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 # AGENTS.md / CLAUDE.md Improver

--- a/skills/agents-md-revise/SKILL.md
+++ b/skills/agents-md-revise/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agents-md-revise
 description: Capture learnings from the current session into the project-rules file (AGENTS.md, CLAUDE.md, or local override) so future sessions benefit. Use when the user says "revise the rules", "update AGENTS.md / CLAUDE.md with what we just learned", "save this to project memory", "remember this for next time", or at the end of a productive session when valuable context has emerged that is not yet documented. This is the COMPLEMENT to agents-md-improver: improver audits, this one captures.
-license: MIT (translated from anthropics/claude-plugins-official/plugins/claude-md-management/commands/revise-claude-md.md)
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 # AGENTS.md / CLAUDE.md Revise

--- a/skills/code-architect/SKILL.md
+++ b/skills/code-architect/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-architect
 description: Design a feature architecture by analyzing existing codebase patterns and conventions, then provide a comprehensive implementation blueprint with specific files to create or modify, component designs, data flows, and a build sequence. Use this skill when the user asks for an architecture design, an implementation plan for a non-trivial feature, or when dispatched as a sub-task during feature-dev architecture phase.
-license: MIT (ported from anthropics/claude-code/plugins/feature-dev/agents/code-architect)
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 # Code Architect

--- a/skills/code-explorer/SKILL.md
+++ b/skills/code-explorer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-explorer
 description: Deeply analyze an existing codebase feature by tracing execution paths, mapping architecture layers, understanding patterns and abstractions, and documenting dependencies. Use this skill when you need to understand how a feature works before modifying or extending it, when dispatched as a sub-task during feature-dev exploration, or when the user asks "how does X work in this codebase".
-license: MIT (ported from anthropics/claude-code/plugins/feature-dev/agents/code-explorer)
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 # Code Explorer

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-review
 description: Review a pull request or a set of code changes for bugs, logic errors, and project-convention violations using a confidence-filtered, multi-agent process. Use this skill when the user asks to review a PR, audit pending changes, or inspect a diff for problems before merging.
-license: MIT (ported from anthropics/claude-code/plugins/code-review)
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 # Code Review

--- a/skills/code-reviewer/SKILL.md
+++ b/skills/code-reviewer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer
 description: Review code for bugs, logic errors, security vulnerabilities, code quality issues, and adherence to project conventions, using confidence-based filtering to report only high-priority issues that truly matter. Use this skill when reviewing a small set of changes locally (such as unstaged diff), when dispatched as a sub-task during feature-dev quality review, or when the user wants a critique of a specific file or function.
-license: MIT (ported from anthropics/claude-code/plugins/feature-dev/agents/code-reviewer)
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 # Code Reviewer

--- a/skills/feature-dev/SKILL.md
+++ b/skills/feature-dev/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: feature-dev
 description: Guide a feature implementation through a structured seven-phase workflow with deep codebase understanding, clarifying questions, parallel architecture design, and quality review. Use this skill when the user asks to build a new feature, add functionality, or wants a methodical approach to implementation rather than diving straight to code.
-license: MIT (ported from anthropics/claude-code/plugins/feature-dev)
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 # Feature Development

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: frontend-design
 description: Create distinctive, production-grade frontend interfaces with high design quality and accessible markup. Use this skill when the user asks to build or beautify web components, pages, applications, landing pages, dashboards, artifacts, or React/HTML/CSS UI. Generates creative, polished code that avoids generic AI aesthetics, then self-checks it against an objective accessibility and quality rubric.
-license: MIT (adapted from anthropics/claude-code/plugins/frontend-design)
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices, then audit it against the self-critique rubric before returning.

--- a/skills/mcp-builder/SKILL.md
+++ b/skills/mcp-builder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mcp-builder
 description: Guide the creation of high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when the user wants to build an MCP server to integrate an external API or service, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
-license: MIT (copied from anthropics/skills/skills/mcp-builder)
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 ## Overview
@@ -147,4 +147,4 @@ Create an XML file with this structure:
 
 ## Notes
 
-This is a port of the upstream `mcp-builder` skill from `anthropics/skills`. The original ships bundled reference files (`reference/mcp_best_practices.md`, `reference/node_mcp_server.md`, `reference/python_mcp_server.md`, `reference/evaluation.md`) which are not included in this port. When you need deeper detail, fetch them directly from <https://github.com/anthropics/skills/tree/main/skills/mcp-builder/reference>.
+This is a modified port of the upstream `mcp-builder` skill from `anthropics/skills`. The original ships bundled reference files (`reference/mcp_best_practices.md`, `reference/node_mcp_server.md`, `reference/python_mcp_server.md`, `reference/evaluation.md`) which are not included in this port. The reviewed upstream snapshot is pinned in `UPSTREAMS.json`.

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: security-review
 description: Perform a focused security review of pending git changes to identify high-confidence security vulnerabilities with real exploitation potential. Use this skill when the user asks for a security review, security audit, vulnerability scan, or wants to check pending changes on a branch for security issues before merging. This is NOT a general code review.
-license: MIT (ported from anthropics/claude-code-security-review/.claude/commands/security-review.md)
+license: MIT (modified; see UPSTREAMS.json)
 ---
 
 # Security Review

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skill-creator
 description: Create new skills (SKILL.md files), modify and improve existing skills, and design skill descriptions for accurate triggering. Use when the user wants to create a new skill from scratch, edit an existing skill, optimize a skill's description, or convert a workflow they just demonstrated into a reusable skill.
-license: MIT (adapted from anthropics/skills/skills/skill-creator)
+license: Apache-2.0 (modified; see UPSTREAMS.json)
 ---
 
 # Skill Creator
@@ -153,4 +153,4 @@ The `description` field is the primary mechanism that determines whether the mod
 
 ## Notes
 
-This is an adapted port of `anthropics/skills/skills/skill-creator`. The upstream version ships bundled scripts and an HTML eval viewer (`scripts/aggregate_benchmark.py`, `eval-viewer/generate_review.py`, etc.) that are not included here. For automated benchmarking infrastructure, see <https://github.com/anthropics/skills/tree/main/skills/skill-creator>.
+This is a modified port of `anthropics/skills/skills/skill-creator`. The upstream version ships bundled scripts and an HTML eval viewer (`scripts/aggregate_benchmark.py`, `eval-viewer/generate_review.py`, etc.) that are not included here. The reviewed upstream snapshot is pinned in `UPSTREAMS.json`.

--- a/tests/provenance.test.mjs
+++ b/tests/provenance.test.mjs
@@ -1,0 +1,73 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO = process.env.REPO || process.cwd();
+const manifestPath = join(REPO, "UPSTREAMS.json");
+const COMMIT_RE = /^[0-9a-f]{40}$/;
+const REVIEW_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function frontmatter(file) {
+  const text = readFileSync(file, "utf8");
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  assert.ok(match, `${file}: YAML frontmatter exists`);
+  return Object.fromEntries(match[1].split(/\r?\n/).map((line) => {
+    const separator = line.indexOf(":");
+    return [line.slice(0, separator).trim(), line.slice(separator + 1).trim()];
+  }));
+}
+
+test("provenance manifest covers every shipped skill with an immutable source", () => {
+  assert.ok(existsSync(manifestPath), "UPSTREAMS.json exists");
+
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const skillNames = readdirSync(join(REPO, "skills"))
+    .filter((name) => existsSync(join(REPO, "skills", name, "SKILL.md")))
+    .sort();
+  const entries = manifest.skills.toSorted((a, b) => a.name.localeCompare(b.name));
+
+  assert.deepEqual(entries.map((entry) => entry.name), skillNames);
+  for (const entry of entries) {
+    assert.match(entry.source.commit, COMMIT_RE, `${entry.name}: immutable source commit`);
+    assert.match(entry.source.blob, COMMIT_RE, `${entry.name}: immutable source blob`);
+    assert.match(entry.reviewedAt, REVIEW_DATE_RE, `${entry.name}: review date`);
+    assert.match(entry.source.repository, /^https:\/\/github\.com\/[^/]+\/[^/]+$/);
+    assert.ok(entry.source.path.length > 0, `${entry.name}: source path`);
+    assert.ok(["Apache-2.0", "MIT"].includes(entry.license), `${entry.name}: known license`);
+    assert.ok(["adapted", "ported", "translated"].includes(entry.adaptation), `${entry.name}: adaptation type`);
+  }
+});
+
+test("distributed artifacts carry matching third-party license notices", () => {
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const packageJson = JSON.parse(readFileSync(join(REPO, "package.json"), "utf8"));
+
+  assert.equal(packageJson.license, "MIT AND Apache-2.0");
+
+  for (const entry of manifest.skills) {
+    const expected = `${entry.license} (modified`;
+    const skill = frontmatter(join(REPO, "skills", entry.name, "SKILL.md"));
+    const command = frontmatter(join(REPO, "commands", `${entry.name}.md`));
+    assert.ok(skill.license?.startsWith(expected), `${entry.name}: skill marks the source as modified`);
+    assert.ok(command.license?.startsWith(expected), `${entry.name}: command marks the source as modified`);
+  }
+
+  for (const path of ["UPSTREAMS.json", "THIRD_PARTY_NOTICES.md", "LICENSES"]) {
+    assert.ok(packageJson.files.includes(path), `package includes ${path}`);
+  }
+  assert.ok(existsSync(join(REPO, "LICENSES", "Apache-2.0.txt")));
+  assert.ok(existsSync(join(REPO, "LICENSES", "Anthropic-security-review-MIT.txt")));
+});
+
+test("provenance includes the adapted OpenCode plugin pattern", () => {
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  assert.ok(Array.isArray(manifest.components), "component provenance exists");
+  const component = manifest.components.find((entry) => entry.name === "opencode-plugin-pattern");
+
+  assert.equal(component.license, "MIT");
+  assert.equal(component.source.repository, "https://github.com/obra/superpowers");
+  assert.match(component.source.commit, COMMIT_RE);
+  assert.match(component.source.blob, COMMIT_RE);
+  assert.ok(existsSync(join(REPO, "LICENSES", "Superpowers-MIT.txt")));
+});


### PR DESCRIPTION
## Summary
- record immutable upstream commits, paths, and Git blobs for every skill
- package Apache and MIT notices for all modified upstream material
- align skill, command, package, plugin, and README licensing metadata

## Validation
- npm test (71 tests passed)
- npm pack --dry-run (32 expected files)
- git diff --check main...HEAD

## Notes
This is the first PR in the approved hardening stack. It documents technical open-source provenance and does not provide legal advice.