### PR TITLE
Prepare version 0.5.0 for the portable native sandbox release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "opencode-power-pack",
   "displayName": "OpenCode Power Pack",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Fifty-four software-development workflows for Claude Code, Codex, OpenCode, and Pi.",
   "author": {
     "name": "Wayner Barrios",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-power-pack",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Fifty-four software-development workflows for Claude Code, Codex, OpenCode, and Pi.",
   "author": {
     "name": "Wayner Barrios",

--- a/.github/workflows/publish-github-package.yml
+++ b/.github/workflows/publish-github-package.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: Release tag to publish, for example v0.4.0
+        description: Release tag to publish, for example v0.5.0
         required: true
-        default: v0.4.0
+        default: v0.5.0
 
 concurrency:
   group: github-package-${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.release.tag_name }}

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Run the installer directly from the mirror after authentication:
 npx --registry=https://npm.pkg.github.com @waybarrios/opencode-power-pack list
 ```
 
-Maintainers publish the mirror with the `Publish GitHub Package` workflow. Release events publish automatically, while a manual run requires an existing release tag such as `v0.4.0`. The workflow verifies that the tag matches `package.json`, runs the complete `prepublishOnly` test suite, and authenticates with the repository-scoped `GITHUB_TOKEN`; no package token is stored in the repository.
+Maintainers publish the mirror with the `Publish GitHub Package` workflow. Release events publish automatically, while a manual run requires an existing release tag such as `v0.5.0`. The workflow verifies that the tag matches `package.json`, runs the complete `prepublishOnly` test suite, and authenticates with the repository-scoped `GITHUB_TOKEN`; no package token is stored in the repository.
 
 | Profile | Intended use |
 |---|---|

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -74,7 +74,7 @@
   <!-- bottom-right voltage stamp -->
   <g transform="translate(1050, 290)" font-family="ui-monospace, monospace">
     <rect x="0" y="0" width="124" height="36" fill="none" stroke="#FFE15D" stroke-width="1.25"/>
-    <text x="62" y="24" font-size="14" font-weight="800" fill="#FFE15D" text-anchor="middle" letter-spacing="3">v0.4.0</text>
+    <text x="62" y="24" font-size="14" font-weight="800" fill="#FFE15D" text-anchor="middle" letter-spacing="3">v0.5.0</text>
   </g>
 
   <!-- top-left registry mark -->

--- a/docs/sandbox-compatibility.md
+++ b/docs/sandbox-compatibility.md
@@ -2,7 +2,7 @@
 
 This document defines what sandbox compatibility means for Codex, Claude Code, OpenCode, and Pi. It separates portable policy support from automatic host enforcement so installation never implies a security guarantee that is not active.
 
-Last verified: 2026-08-16
+Last verified: 2026-08-17
 
 Locally inspected host versions:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@waybarrios/opencode-power-pack",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@waybarrios/opencode-power-pack",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.73"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waybarrios/opencode-power-pack",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Fifty-four software-development workflows for Claude Code, Codex, OpenCode, and Pi: code review, feature development, security review, frontend design, authoring, and project memory.",
   "type": "module",
   "main": ".opencode/plugins/opencode-power-pack.js",


### PR DESCRIPTION
## Summary

- bump npm, Claude Code, and Codex package metadata to version 0.5.0
- update the GitHub Packages release workflow example and default
- refresh the branded release marker
- record the final sandbox compatibility verification date

## Validation

- 400 tests executed on Node.js 20.11.1 with 399 passing and one expected native integration skip
- sandbox contract and runtime tests passing
- OpenCode 1.18.7 smoke validation passing
- strict Claude Code plugin validation passing
- packed npm installation verified with all sandbox runtime, contract, schema, and documentation resources