### PR TITLE
Keep release tests independent from the publishing registry

### DIFF
--- a/tests/package-surface.test.mjs
+++ b/tests/package-surface.test.mjs
@@ -100,6 +100,7 @@ test("packed npm artifact exposes a working selective-installer executable", () 
     npm_config_dry_run: "false",
     npm_config_json: "false",
     npm_config_loglevel: "silent",
+    npm_config_registry: "https://registry.npmjs.org/",
   };
   try {
     mkdirSync(installRoot, { recursive: true });


### PR DESCRIPTION
## Summary

- force temporary package consumer installations to use the public npm registry
- prevent GitHub Packages publishing configuration from redirecting test dependencies
- keep the package-surface test reproducible across release registries

## Verification

- simulated GitHub Packages registry: 3 package-surface tests passed
- full test suite: 399 passed, 1 expected skip
- git diff check passed