### PR TITLE
Publish release artifacts without rerunning package lifecycle tests

### DIFF
--- a/.github/workflows/publish-github-package.yml
+++ b/.github/workflows/publish-github-package.yml
@@ -46,6 +46,6 @@ jobs:
             }
           '
       - name: Publish release to GitHub Packages
-        run: npm publish --registry=https://npm.pkg.github.com --access public
+        run: npm publish --ignore-scripts --registry=https://npm.pkg.github.com --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/github-packages.test.mjs
+++ b/tests/github-packages.test.mjs
@@ -21,7 +21,7 @@ test("GitHub Packages workflow publishes an exact release tag with least privile
   assert.match(WORKFLOW, /scope: "@waybarrios"/);
   assert.match(
     WORKFLOW,
-    /npm publish --registry=https:\/\/npm\.pkg\.github\.com --access public/,
+    /npm publish --ignore-scripts --registry=https:\/\/npm\.pkg\.github\.com --access public/,
   );
   assert.match(WORKFLOW, /NODE_AUTH_TOKEN: \$\{\{ secrets\.GITHUB_TOKEN \}\}/);
 });


### PR DESCRIPTION
## Summary

- skip npm lifecycle scripts during the GitHub Packages upload
- rely on the release tag’s completed CI verification
- preserve the immutable version 0.5.0 tag while avoiding registry leakage into package tests

## Verification

- GitHub Packages workflow tests passed
- package-surface tests passed
- full suite: 399 passed, 1 expected skip
- merged main CI passed